### PR TITLE
不要なコマンドライン引数を与えたときに停止するようにする

### DIFF
--- a/mailq-filter
+++ b/mailq-filter
@@ -15,6 +15,8 @@ GetOptions(
     help        => sub { pod2usage(0); },
 ) || exit(1);
 
+pod2usage(0) if @ARGV > 0;
+
 $opt_from  = $opt_to = '^' if $opt_count;
 
 $|++;


### PR DESCRIPTION
mailq-filterはフラグでないコマンドライン引数を取りませんが，指定したとしても特になにも起こらないだけなので，使い方を間違っていても気づかないおそれがあります．そのような場合はキューにあるすべてのメールが出力されるので，うっかり削除すると危険です

このパッチでは `mailq-filter arg` のように引数を与えた際には，usageを出力して停止するようにします．
